### PR TITLE
Rename 3.0 to 2.5

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -4,8 +4,8 @@
 "use strict";
 
 var config = {
-  releases: ["1.3", "1.3T", "1.4", "2.0", "2.0M", "2.1", "2.1S", "2.2", "2.3", "2.4", "2.5"], // which releases to show
-  featureReleases: ["2.2?", "2.2+", "2.3?", "2.3+", "3.0?", "3.0+"], // for feature-b2g transition. 
+  releases: ["1.3", "1.3T", "1.4", "2.0", "2.0M", "2.1", "2.1S", "2.2", "2.5"], // which releases to show
+  featureReleases: ["2.2?", "2.2+", "2.3?", "2.3+", "2.5?", "2.5+"], // for feature-b2g transition. 
   flag: "cf_blocking_b2g", // name of the release flag to use
   feature_flag: "cf_feature_b2g", 
   reload: 300, // reload every this many seconds (0 means disabled)


### PR DESCRIPTION
Hi Kevin,
I just realized the dashboard on mana still shows 3.0 not 2.5.
Just a PR for renaming 3.0 flag to 2.5. Please help to review. Thanks!